### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,8 +23,8 @@ jobs:
           - { test: 2, php: ^8.1, laravel: ^10.0, testbench: ^8.0, collision: ^7.0, phpunit: 9.6}
           - { test: 3, php: ^8.2, laravel: ^10.0, testbench: ^8.0, collision: ^7.0, phpunit: 9.6}
           - { test: 4, php: ^8.3, laravel: ^10.0, testbench: ^8.0, collision: ^7.0, phpunit: 9.6}
-          - { test: 5, php: ^8.2, laravel: ^11.0, testbench: ^9.0, collision: ^8.0, phpunit: 10.5}
-          - { test: 6, php: ^8.3, laravel: ^11.0, testbench: ^9.0, collision: ^8.0, phpunit: 10.5}
+          - { test: 5, php: ^8.2, laravel: ^11.0, testbench: ^9.0, collision: ^8.0, phpunit: 10.5.1}
+          - { test: 6, php: ^8.3, laravel: ^11.0, testbench: ^9.0, collision: ^8.0, phpunit: 10.5.1}
 
 
     steps:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,12 +17,14 @@ jobs:
       fail-fast: true
       matrix:
         dependency_version: [prefer-stable]
-        test: [1, 2, 3, 4]
+        test: [1, 2, 3, 4, 5, 6]
         include:
           - { test: 1, php: ^8.1, laravel: ^9.0, testbench: ^7.0, collision: ^6.1, phpunit: 9.5.10 }
           - { test: 2, php: ^8.1, laravel: ^10.0, testbench: ^8.0, collision: ^7.0, phpunit: 9.6}
           - { test: 3, php: ^8.2, laravel: ^10.0, testbench: ^8.0, collision: ^7.0, phpunit: 9.6}
           - { test: 4, php: ^8.3, laravel: ^10.0, testbench: ^8.0, collision: ^7.0, phpunit: 9.6}
+          - { test: 5, php: ^8.2, laravel: ^11.0, testbench: ^9.0, collision: ^8.0, phpunit: 9.6}
+          - { test: 6, php: ^8.3, laravel: ^11.0, testbench: ^9.0, collision: ^8.0, phpunit: 9.6}
 
 
     steps:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,8 +23,8 @@ jobs:
           - { test: 2, php: ^8.1, laravel: ^10.0, testbench: ^8.0, collision: ^7.0, phpunit: 9.6}
           - { test: 3, php: ^8.2, laravel: ^10.0, testbench: ^8.0, collision: ^7.0, phpunit: 9.6}
           - { test: 4, php: ^8.3, laravel: ^10.0, testbench: ^8.0, collision: ^7.0, phpunit: 9.6}
-          - { test: 5, php: ^8.2, laravel: ^11.0, testbench: ^9.0, collision: ^8.0, phpunit: 9.6}
-          - { test: 6, php: ^8.3, laravel: ^11.0, testbench: ^9.0, collision: ^8.0, phpunit: 9.6}
+          - { test: 5, php: ^8.2, laravel: ^11.0, testbench: ^9.0, collision: ^8.0, phpunit: 10.5}
+          - { test: 6, php: ^8.3, laravel: ^11.0, testbench: ^9.0, collision: ^8.0, phpunit: 10.5}
 
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^7.0|^8.0|^9.0",
-        "phpunit/phpunit": "^9.3.3|^9.6",
+        "phpunit/phpunit": "^9.3.3|^9.6|^10.5",
         "nunomaduro/collision": "^6.1|^7.0|^8.0",
         "laravel/pint": "^1.14"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     ],
     "require": {
         "php": "^7.3|^8.1",
-        "illuminate/support": "^9.0|^10.0"
+        "illuminate/support": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0|^8.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.3.3|^9.6",
-        "nunomaduro/collision": "^6.1|^7.0",
+        "nunomaduro/collision": "^6.1|^7.0|^8.0",
         "laravel/pint": "^1.14"
     },
     "autoload": {


### PR DESCRIPTION
Technically it works but your tests will need updating to support PHPUnit 10, which is going to be difficult whilst maintain backwards compatibility with older versions.